### PR TITLE
feat(member): :sparkles: Caso de uso para remover a un miembro del workspace

### DIFF
--- a/src/workspace/application/delete-member-use-case/delete-member-use-case.ts
+++ b/src/workspace/application/delete-member-use-case/delete-member-use-case.ts
@@ -1,0 +1,29 @@
+import { CollaboratorRepository } from '@/workspace/domain/repositories/collaborator.repository';
+import { DeleteMemberDto } from './delete-member.dto';
+import { UserNoExistException } from '@/workspace/domain/exceptions/user-no.exist.exception';
+import { Injectable, Transactional } from '@/shared/dependencies';
+import { WorkspaceRepository } from '@/workspace/domain/repositories/workspace.repository';
+import { WorkspaceNoExistException } from '@/workspace/domain/exceptions/workspace-no.exist.exception';
+
+@Injectable()
+export class DeleteMemberUseCase {
+  constructor(
+    private readonly collaboratorRepository: CollaboratorRepository,
+    private readonly workspaceRepository: WorkspaceRepository,
+  ) {}
+
+  @Transactional()
+  async run(deleteMemberDto: DeleteMemberDto): Promise<void> {
+    const { user, workspace } = deleteMemberDto;
+
+    const existWorkspace = await this.workspaceRepository.findById(workspace);
+
+    if (!existWorkspace) throw new WorkspaceNoExistException(workspace);
+
+    const wasMemberDeleted =
+      await this.collaboratorRepository.deleteMember(deleteMemberDto);
+
+    if (!wasMemberDeleted)
+      throw new UserNoExistException(`${user} in the workspace`);
+  }
+}

--- a/src/workspace/application/delete-member-use-case/delete-member.dto.ts
+++ b/src/workspace/application/delete-member-use-case/delete-member.dto.ts
@@ -1,0 +1,4 @@
+export interface DeleteMemberDto {
+  workspace: string;
+  user: string;
+}

--- a/src/workspace/domain/exceptions/workspace-no.exist.exception.ts
+++ b/src/workspace/domain/exceptions/workspace-no.exist.exception.ts
@@ -1,0 +1,5 @@
+export class WorkspaceNoExistException extends Error {
+  constructor(name: string) {
+    super(`Workspace ${name} does not exist`);
+  }
+}

--- a/src/workspace/domain/repositories/collaborator.repository.ts
+++ b/src/workspace/domain/repositories/collaborator.repository.ts
@@ -10,4 +10,8 @@ export abstract class CollaboratorRepository {
     role: string;
     workspace: string;
   }): Promise<Member | null>;
+  abstract deleteMember(options: {
+    workspace: string;
+    user: string;
+  }): Promise<boolean>;
 }

--- a/src/workspace/domain/repositories/workspace.repository.ts
+++ b/src/workspace/domain/repositories/workspace.repository.ts
@@ -2,4 +2,5 @@ import { Workspace } from '../entities/workspace.entity';
 export abstract class WorkspaceRepository {
   abstract create(workspace: Workspace): Promise<Workspace>;
   abstract listByUser(options: { user: string }): Promise<Workspace[]>;
+  abstract findById(id: string): Promise<Workspace | null>;
 }

--- a/src/workspace/infrastructure/api/delete-member/delete-member-http.dto.ts
+++ b/src/workspace/infrastructure/api/delete-member/delete-member-http.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class DeleteMemberHttpDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  workspace: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  user: string;
+}

--- a/src/workspace/infrastructure/api/delete-member/delete-member.controller.ts
+++ b/src/workspace/infrastructure/api/delete-member/delete-member.controller.ts
@@ -1,0 +1,36 @@
+import { COLLABORATOR_ROUTE, WORKSPACE_ROUTE } from '@/workspace/routes';
+import {
+  Controller,
+  Delete,
+  InternalServerErrorException,
+  NotFoundException,
+  Param,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { DeleteMemberHttpDto } from './delete-member-http.dto';
+import { DeleteMemberUseCase } from '@/workspace/application/delete-member-use-case/delete-member-use-case';
+import { UserNoExistException } from '@/workspace/domain/exceptions/user-no.exist.exception';
+import { WorkspaceNoExistException } from '@/workspace/domain/exceptions/workspace-no.exist.exception';
+
+@Controller(COLLABORATOR_ROUTE)
+@ApiTags(WORKSPACE_ROUTE)
+export class DeleteMemberController {
+  constructor(private readonly deleteMemberUseCase: DeleteMemberUseCase) {}
+
+  @Delete(':workspace/:user')
+  async run(@Param() deleteMemberHttpDto: DeleteMemberHttpDto) {
+    try {
+      await this.deleteMemberUseCase.run(deleteMemberHttpDto);
+
+      return { message: 'User deleted from workspace' };
+    } catch (error) {
+      if (
+        error instanceof UserNoExistException ||
+        error instanceof WorkspaceNoExistException
+      )
+        throw new NotFoundException(error.message);
+
+      throw new InternalServerErrorException(error);
+    }
+  }
+}

--- a/src/workspace/infrastructure/respositories/relational.collaborator.repository.ts
+++ b/src/workspace/infrastructure/respositories/relational.collaborator.repository.ts
@@ -103,4 +103,24 @@ export class RelationalCollaboratorRepository extends CollaboratorRepository {
 
     return this.userMapper.toDomain(user);
   }
+
+  async deleteMember(options: {
+    workspace: string;
+    user: string;
+  }): Promise<boolean> {
+    const { workspace, user } = options;
+
+    const member = await this.collaboratorModel.findOne({
+      where: {
+        user_id: user,
+        workspace_id: workspace,
+      },
+    });
+
+    if (!member) return false;
+
+    await member.destroy();
+
+    return true;
+  }
 }

--- a/src/workspace/infrastructure/respositories/relational.workspace.repository.ts
+++ b/src/workspace/infrastructure/respositories/relational.workspace.repository.ts
@@ -40,4 +40,14 @@ export class RelationalWorkspaceRepository extends WorkspaceRepository {
       this.workspaceMapper.toDomain(workspace),
     );
   }
+
+  async findById(id: string): Promise<Workspace | null> {
+    const workspace = await this.workspaceModel.findByPk(id, {
+      include: [CollaboratorModel],
+    });
+
+    if (!workspace) return null;
+
+    return this.workspaceMapper.toDomain(workspace);
+  }
 }

--- a/src/workspace/workspace.module.ts
+++ b/src/workspace/workspace.module.ts
@@ -3,6 +3,8 @@ import { CollaboratorRepository } from './domain/repositories/collaborator.repos
 import { CreateWorkspaceController } from './infrastructure/api/create-workspace/create-workspace.controller';
 import { CreateWorkspaceResource } from './infrastructure/api/create-workspace/create-workspace.resource';
 import { CreateWorkspaceUseCase } from './application/create-workspace-use-case/create-workspace-use-case';
+import { DeleteMemberController } from './infrastructure/api/delete-member/delete-member.controller';
+import { DeleteMemberUseCase } from './application/delete-member-use-case/delete-member-use-case';
 import { ListCollaboratorController } from './infrastructure/api/list-collaborator/list-collaborator.controller';
 import { ListCollaboratorUseCase } from './application/list-collaborator-use-case/list-collaborator-use-case';
 import { ListRolCollaboratorController } from './infrastructure/api/list-rol-collaborator/list-rol-collaborator.controller';
@@ -38,6 +40,7 @@ import WorkspaceModel from './infrastructure/models/workspace.model';
     ListCollaboratorController,
     ListWorkspaceController,
     UpdateRolMemberController,
+    DeleteMemberController,
   ],
   imports: [
     SequelizeModule.forFeature([
@@ -54,6 +57,7 @@ import WorkspaceModel from './infrastructure/models/workspace.model';
     CollaboratorMapper,
     CreateWorkspaceResource,
     CreateWorkspaceUseCase,
+    DeleteMemberUseCase,
     ListCollaboratorUseCase,
     ListRolCollaboratorUseCase,
     ListWorkspaceResource,
@@ -79,6 +83,10 @@ import WorkspaceModel from './infrastructure/models/workspace.model';
       useExisting: RelationalCollaboratorRepository,
     },
   ],
-  exports: [CreateWorkspaceUseCase, ListCollaboratorUseCase],
+  exports: [
+    CreateWorkspaceUseCase,
+    ListCollaboratorUseCase,
+    DeleteMemberUseCase,
+  ],
 })
 export class WorkspaceModule {}


### PR DESCRIPTION

Se agrego el caso de uso que permite remover a un miembro de un espacio de trabajo,
se esta utiizando las eliminaciones pasivas con el paranoid de sequelize

![Captura desde 2024-08-21 08-27-32](https://github.com/user-attachments/assets/8b74beb7-1f20-4ede-b5ae-3a9840895f86)
